### PR TITLE
fix: check for github-actions[bot] in codex-reply workflow

### DIFF
--- a/.github/workflows/codex-reply.yml
+++ b/.github/workflows/codex-reply.yml
@@ -45,7 +45,7 @@ jobs:
             fi
 
             ORIGINAL_AUTHOR=$(gh api "$API_PATH" --jq '.user.login' 2>/dev/null || echo "")
-            if [ "$ORIGINAL_AUTHOR" = "github-actions" ]; then
+            if [ "$ORIGINAL_AUTHOR" = "github-actions[bot]" ]; then
               echo "is_ai_reply=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi


### PR DESCRIPTION
## Summary

Codex Reply 워크플로우가 AI 댓글에 대한 답글을 인식하지 못하는 버그 수정

- 봇 사용자 로그인이 `github-actions`가 아닌 `github-actions[bot]`임
- 이로 인해 AI 댓글에 대한 답글이 무시되고 있었음

## Test plan

- [ ] PR #9에서 AI 인라인 서제스천에 댓글 달기
- [ ] Codex Reply 워크플로우가 응답하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)