### PR TITLE
feat(api): RESTful API 리팩토링 및 세션 중심 설계

### DIFF
--- a/poc/src/api/app.py
+++ b/poc/src/api/app.py
@@ -25,7 +25,7 @@ app.add_middleware(
 )
 
 # API 라우트 등록
-app.include_router(router, prefix="/api")
+app.include_router(router, prefix="/v1")
 
 # Static 파일 서빙 (UI)
 static_dir = Path(__file__).parent.parent.parent / "static"

--- a/poc/src/api/routes.py
+++ b/poc/src/api/routes.py
@@ -2,7 +2,9 @@
 import json
 import uuid
 from datetime import datetime, timezone
-from typing import AsyncGenerator, Optional, Dict
+from typing import AsyncGenerator, Optional, Dict, List, Union
+
+from langchain_core.messages import BaseMessage
 
 from fastapi import APIRouter, HTTPException, Depends, Header
 
@@ -62,7 +64,7 @@ async def get_current_user(authorization: Optional[str] = Header(None)) -> Optio
     return token
 
 
-def require_user_id(user_id: Optional[str], mem=None) -> Optional[str]:
+def require_user_id(user_id: Optional[str], mem: Union[InMemoryChatMemory, SupabaseChatMemory, None] = None) -> Optional[str]:
     """Supabase 모드에서 user_id 필수 검증
 
     Args:
@@ -84,7 +86,7 @@ def require_user_id(user_id: Optional[str], mem=None) -> Optional[str]:
     return user_id
 
 
-def _extract_timestamps(messages) -> tuple[Optional[str], Optional[str]]:
+def _extract_timestamps(messages: List[BaseMessage]) -> tuple[Optional[str], Optional[str]]:
     """메시지 목록에서 생성 시간과 마지막 활동 시간 추출
 
     Args:

--- a/poc/src/api/routes.py
+++ b/poc/src/api/routes.py
@@ -219,7 +219,7 @@ async def send_message(
     session_id: str,
     body: MessageRequest,
     user_id: Optional[str] = Depends(get_current_user)
-):
+) -> Union[EventSourceResponse, ChatResponse]:
     """메시지 전송 (body.stream으로 스트리밍/JSON 구분)
 
     Args:

--- a/poc/src/api/routes.py
+++ b/poc/src/api/routes.py
@@ -159,7 +159,8 @@ async def create_session(
         # InMemoryChatMemory
         memory.init_session(session_id)
 
-    logger.info(f"Created new session: {session_id} for user: {user_id or 'anonymous'}")
+    # user_id는 토큰이므로 로그에 출력하지 않음 (credential leak 방지)
+    logger.info(f"Created new session: {session_id}")
 
     return SessionCreateResponse(
         session_id=session_id,

--- a/poc/src/api/routes.py
+++ b/poc/src/api/routes.py
@@ -1,9 +1,10 @@
 """API 라우트 정의"""
 import json
 import uuid
+from datetime import datetime, timezone
 from typing import AsyncGenerator, Optional, Dict
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends, Header
 
 from sse_starlette.sse import EventSourceResponse
 from loguru import logger
@@ -12,14 +13,95 @@ from src.supervisor import Supervisor
 from src.memory import InMemoryChatMemory, SupabaseChatMemory
 from config import config
 from .schemas import (
-    ChatRequest,
+    MessageRequest,
     ChatResponse,
+    SessionCreateResponse,
+    SessionDetailResponse,
     SessionInfo,
     SessionListResponse,
     SessionHistoryResponse,
     MessageInfo,
     HealthResponse,
 )
+
+
+async def get_current_user(authorization: Optional[str] = Header(None)) -> Optional[str]:
+    """Authorization 헤더에서 user_id 추출
+
+    TODO: 실제 JWT 검증 로직 구현 필요
+    현재는 Bearer 토큰을 user_id로 직접 사용 (개발용)
+
+    Args:
+        authorization: Authorization 헤더 (Bearer <token>)
+
+    Returns:
+        user_id 또는 None (InMemory 모드)
+
+    Raises:
+        HTTPException: Supabase 모드에서 토큰 없을 때
+    """
+    if not authorization:
+        return None
+
+    # Bearer 토큰 파싱
+    parts = authorization.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid authorization header format. Use: Bearer <token>"
+        )
+
+    token = parts[1]
+
+    # TODO: JWT 검증 및 user_id 추출
+    # 현재는 토큰을 그대로 user_id로 사용 (개발용)
+    # 실제 구현 시:
+    # decoded = jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
+    # return decoded["sub"]  # or decoded["user_id"]
+
+    return token
+
+
+def require_user_id(user_id: Optional[str], mem=None) -> Optional[str]:
+    """Supabase 모드에서 user_id 필수 검증
+
+    Args:
+        user_id: 사용자 ID (Authorization 헤더에서 추출)
+        mem: 메모리 인스턴스 (테스트용, 기본값은 전역 memory 사용)
+
+    Returns:
+        user_id (Supabase 모드) 또는 None (InMemory 모드)
+
+    Raises:
+        HTTPException: Supabase 모드에서 user_id 없을 때
+    """
+    mem = mem or memory
+    if isinstance(mem, SupabaseChatMemory) and not user_id:
+        raise HTTPException(
+            status_code=401,
+            detail="Authorization header required. Use: Bearer <token>"
+        )
+    return user_id
+
+
+def _extract_timestamps(messages) -> tuple[Optional[str], Optional[str]]:
+    """메시지 목록에서 생성 시간과 마지막 활동 시간 추출
+
+    Args:
+        messages: BaseMessage 목록
+
+    Returns:
+        (created_at, last_activity) 튜플
+    """
+    if not messages:
+        return None, None
+
+    first_msg = messages[0]
+    created_at = first_msg.additional_kwargs.get("timestamp")
+    last_msg = messages[-1]
+    last_activity = last_msg.additional_kwargs.get("timestamp")
+
+    return created_at, last_activity
 
 router = APIRouter()
 
@@ -46,146 +128,223 @@ async def health_check() -> HealthResponse:
     )
 
 
-@router.post("/chat", response_model=ChatResponse)
-async def chat(request: ChatRequest) -> ChatResponse:
-    """채팅 (Non-streaming)"""
-    session_id = request.session_id or str(uuid.uuid4())
+@router.post("/sessions", response_model=SessionCreateResponse)
+async def create_session(
+    user_id: Optional[str] = Depends(get_current_user)
+) -> SessionCreateResponse:
+    """새 세션 생성
 
-    # SupabaseChatMemory인 경우 user_id 필수
-    if isinstance(memory, SupabaseChatMemory):
-        if not request.user_id:
-            raise HTTPException(
-                status_code=400,
-                detail="user_id is required when using Supabase backend"
-            )
+    Headers:
+        Authorization: Bearer <token> (Supabase 사용 시 필수)
 
-    try:
-        kwargs = {}
-        if request.user_id:
-            kwargs["user_id"] = request.user_id
-
-        result = await supervisor.process(
-            question=request.message,
-            session_id=session_id,
-            **kwargs
-        )
-        return ChatResponse(
-            answer=result.answer,
-            sources=result.sources,
-            session_id=session_id
-        )
-    except ValueError as e:
-        # Handle user_id validation errors from Supervisor._build_messages
-        logger.error(f"Validation error: {e}")
-        raise HTTPException(
-            status_code=400,
-            detail=str(e)
-        )
-    except Exception as e:
-        logger.exception("Chat processing failed")
-        raise HTTPException(
-            status_code=500,
-            detail="요청 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
-        )
-
-
-@router.post("/chat/stream")
-async def chat_stream(request: ChatRequest) -> EventSourceResponse:
-    """채팅 (SSE Streaming)
-
-    이벤트 타입:
-    - token: LLM 토큰 출력
-    - think: 생각 과정
-    - act: 도구 호출
-    - observe: 도구 결과
-    - done: 스트림 완료
-    - error: 에러 발생
+    Returns:
+        SessionCreateResponse: 생성된 세션 정보
     """
-    # SupabaseChatMemory인 경우 user_id 필수
+    require_user_id(user_id)
+
+    session_id = str(uuid.uuid4())
+    created_at = datetime.now(timezone.utc).isoformat()
+
+    # 세션 저장소에 실제로 세션 생성
     if isinstance(memory, SupabaseChatMemory):
-        if not request.user_id:
+        success = await memory.init_session_async(session_id, user_id)
+        if not success:
             raise HTTPException(
-                status_code=400,
-                detail="user_id is required when using Supabase backend"
+                status_code=500,
+                detail="Failed to create session"
+            )
+    else:
+        # InMemoryChatMemory
+        memory.init_session(session_id)
+
+    logger.info(f"Created new session: {session_id} for user: {user_id or 'anonymous'}")
+
+    return SessionCreateResponse(
+        session_id=session_id,
+        created_at=created_at
+    )
+
+
+@router.get("/sessions/{session_id}", response_model=SessionDetailResponse)
+async def get_session_detail(
+    session_id: str,
+    user_id: Optional[str] = Depends(get_current_user)
+) -> SessionDetailResponse:
+    """세션 상세 정보 조회
+
+    Args:
+        session_id: 세션 ID
+
+    Headers:
+        Authorization: Bearer <token> (Supabase 사용 시 필수)
+
+    Returns:
+        SessionDetailResponse: 세션 상세 정보
+    """
+    require_user_id(user_id)
+
+    if isinstance(memory, SupabaseChatMemory):
+        # 세션 존재 및 소유권 검증
+        user_sessions = await memory.list_sessions_async(user_id=user_id)
+        if session_id not in user_sessions:
+            raise HTTPException(
+                status_code=404,
+                detail="Session not found or access denied"
             )
 
-    session_id = request.session_id or str(uuid.uuid4())
+        message_count = await memory.get_message_count_async(session_id, user_id=user_id)
+        messages = await memory.get_messages_async(session_id, user_id=user_id)
+    else:
+        # InMemoryChatMemory
+        if session_id not in memory.list_sessions():
+            raise HTTPException(status_code=404, detail="Session not found")
 
-    async def event_generator() -> AsyncGenerator[dict, None]:
+        message_count = memory.get_message_count(session_id)
+        messages = memory.get_messages(session_id)
+
+    created_at, last_activity = _extract_timestamps(messages)
+
+    return SessionDetailResponse(
+        session_id=session_id,
+        message_count=message_count,
+        created_at=created_at,
+        last_activity=last_activity
+    )
+
+
+@router.post("/sessions/{session_id}/messages", response_model=None)
+async def send_message(
+    session_id: str,
+    body: MessageRequest,
+    user_id: Optional[str] = Depends(get_current_user)
+):
+    """메시지 전송 (body.stream으로 스트리밍/JSON 구분)
+
+    Args:
+        session_id: 세션 ID
+        body: 메시지 요청 본문 (message, stream)
+
+    Headers:
+        Authorization: Bearer <token> (Supabase 사용 시 필수)
+
+    Returns:
+        - stream: true → SSE 스트리밍 응답
+        - stream: false → JSON 응답
+
+    Events (SSE):
+        - token: LLM 토큰 출력
+        - think: 생각 과정
+        - act: 도구 호출
+        - observe: 도구 결과
+        - done: 스트림 완료
+        - error: 에러 발생
+    """
+    require_user_id(user_id)
+
+    # 스트리밍 응답
+    if body.stream:
+        async def event_generator() -> AsyncGenerator[dict, None]:
+            try:
+                kwargs = {}
+                if user_id:
+                    kwargs["user_id"] = user_id
+
+                async for event in supervisor.process_stream(
+                    question=body.message,
+                    session_id=session_id,
+                    **kwargs
+                ):
+                    event_type = event.get("type", "token")
+
+                    if event_type == "token":
+                        yield {
+                            "event": "token",
+                            "data": json.dumps({"content": event.get("content", "")})
+                        }
+                    elif event_type == "think":
+                        yield {
+                            "event": "think",
+                            "data": json.dumps({"content": event.get("content", "")})
+                        }
+                    elif event_type == "act":
+                        yield {
+                            "event": "act",
+                            "data": json.dumps({
+                                "tool": event.get("tool", ""),
+                                "args": event.get("args", {})
+                            })
+                        }
+                    elif event_type == "observe":
+                        yield {
+                            "event": "observe",
+                            "data": json.dumps({"content": event.get("content", "")})
+                        }
+
+                # 완료 이벤트
+                yield {
+                    "event": "done",
+                    "data": json.dumps({"session_id": session_id})
+                }
+
+            except ValueError as e:
+                logger.error(f"Validation error: {e}")
+                yield {
+                    "event": "error",
+                    "data": json.dumps({"error": str(e)})
+                }
+
+            except Exception as e:
+                logger.exception("Stream processing failed")
+                yield {
+                    "event": "error",
+                    "data": json.dumps({"error": "스트리밍 처리 중 오류가 발생했습니다."})
+                }
+
+        return EventSourceResponse(event_generator())
+
+    # JSON 응답
+    else:
         try:
             kwargs = {}
-            if request.user_id:
-                kwargs["user_id"] = request.user_id
+            if user_id:
+                kwargs["user_id"] = user_id
 
-            async for event in supervisor.process_stream(
-                question=request.message,
+            result = await supervisor.process(
+                question=body.message,
                 session_id=session_id,
                 **kwargs
-            ):
-                event_type = event.get("type", "token")
-
-                if event_type == "token":
-                    yield {
-                        "event": "token",
-                        "data": json.dumps({"content": event.get("content", "")})
-                    }
-                elif event_type == "think":
-                    yield {
-                        "event": "think",
-                        "data": json.dumps({"content": event.get("content", "")})
-                    }
-                elif event_type == "act":
-                    yield {
-                        "event": "act",
-                        "data": json.dumps({
-                            "tool": event.get("tool", ""),
-                            "args": event.get("args", {})
-                        })
-                    }
-                elif event_type == "observe":
-                    yield {
-                        "event": "observe",
-                        "data": json.dumps({"content": event.get("content", "")})
-                    }
-
-            # 완료 이벤트
-            yield {
-                "event": "done",
-                "data": json.dumps({"session_id": session_id})
-            }
-
+            )
+            return ChatResponse(
+                answer=result.answer,
+                sources=result.sources,
+                session_id=session_id
+            )
         except ValueError as e:
-            # Handle user_id validation errors from Supervisor._build_messages
             logger.error(f"Validation error: {e}")
-            yield {
-                "event": "error",
-                "data": json.dumps({"error": str(e)})
-            }
-            
+            raise HTTPException(
+                status_code=400,
+                detail=str(e)
+            )
         except Exception as e:
-            logger.exception("Stream processing failed")
-            yield {
-                "event": "error",
-                "data": json.dumps({"error": "스트리밍 처리 중 오류가 발생했습니다."})
-            }
-
-    return EventSourceResponse(event_generator())
+            logger.exception("Chat processing failed")
+            raise HTTPException(
+                status_code=500,
+                detail="요청 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+            )
 
 
 @router.get("/sessions", response_model=SessionListResponse)
-async def list_sessions(user_id: Optional[str] = None) -> SessionListResponse:
+async def list_sessions(
+    user_id: Optional[str] = Depends(get_current_user)
+) -> SessionListResponse:
     """세션 목록 조회
 
-    Args:
-        user_id: 사용자 ID (Supabase 사용 시 필수)
+    Headers:
+        Authorization: Bearer <token> (Supabase 사용 시 필수)
     """
-    # SupabaseChatMemory인 경우 user_id 필수
+    require_user_id(user_id)
+
     if isinstance(memory, SupabaseChatMemory):
-        if not user_id:
-            raise HTTPException(
-                status_code=400,
-                detail="user_id is required when using Supabase backend"
-            )
         session_ids = await memory.list_sessions_async(user_id=user_id)
         sessions = [
             SessionInfo(
@@ -209,20 +368,21 @@ async def list_sessions(user_id: Optional[str] = None) -> SessionListResponse:
 
 
 @router.get("/sessions/{session_id}/messages", response_model=SessionHistoryResponse)
-async def get_session_messages(session_id: str, user_id: Optional[str] = None) -> SessionHistoryResponse:
+async def get_session_messages(
+    session_id: str,
+    user_id: Optional[str] = Depends(get_current_user)
+) -> SessionHistoryResponse:
     """세션의 대화 히스토리 조회
 
     Args:
         session_id: 세션 ID
-        user_id: 사용자 ID (Supabase 사용 시 필수)
+
+    Headers:
+        Authorization: Bearer <token> (Supabase 사용 시 필수)
     """
-    # SupabaseChatMemory인 경우 user_id 필수 및 소유권 검증
+    require_user_id(user_id)
+
     if isinstance(memory, SupabaseChatMemory):
-        if not user_id:
-            raise HTTPException(
-                status_code=400,
-                detail="user_id is required when using Supabase backend"
-            )
         messages = await memory.get_messages_async(session_id, user_id=user_id)
     else:
         # InMemoryChatMemory는 user_id 무시
@@ -244,20 +404,21 @@ async def get_session_messages(session_id: str, user_id: Optional[str] = None) -
 
 
 @router.delete("/sessions/{session_id}")
-async def delete_session(session_id: str, user_id: Optional[str] = None) -> Dict[str, str]:
+async def delete_session(
+    session_id: str,
+    user_id: Optional[str] = Depends(get_current_user)
+) -> Dict[str, str]:
     """세션 삭제
 
     Args:
         session_id: 세션 ID
-        user_id: 사용자 ID (Supabase 사용 시 필수)
+
+    Headers:
+        Authorization: Bearer <token> (Supabase 사용 시 필수)
     """
-    # SupabaseChatMemory인 경우 user_id 필수 및 소유권 검증
+    require_user_id(user_id)
+
     if isinstance(memory, SupabaseChatMemory):
-        if not user_id:
-            raise HTTPException(
-                status_code=400,
-                detail="user_id is required when using Supabase backend"
-            )
         # 소유권 검증
         user_sessions = await memory.list_sessions_async(user_id=user_id)
         if session_id not in user_sessions:
@@ -270,30 +431,3 @@ async def delete_session(session_id: str, user_id: Optional[str] = None) -> Dict
         memory.delete_session(session_id)
 
     return {"message": "Session deleted", "session_id": session_id}
-
-
-@router.delete("/sessions/{session_id}/messages")
-async def clear_session(session_id: str, user_id: Optional[str] = None) -> Dict[str, str]:
-    """세션 메시지 초기화
-
-    Args:
-        session_id: 세션 ID
-        user_id: 사용자 ID (Supabase 사용 시 필수)
-    """
-    # SupabaseChatMemory인 경우 user_id 필수 및 소유권 검증
-    if isinstance(memory, SupabaseChatMemory):
-        if not user_id:
-            raise HTTPException(
-                status_code=400,
-                detail="user_id is required when using Supabase backend"
-            )
-        # 소유권 검증
-        user_sessions = await memory.list_sessions_async(user_id=user_id)
-        if session_id not in user_sessions:
-            raise HTTPException(status_code=404, detail="Session not found or access denied")
-        await memory.clear_async(session_id, user_id=user_id)
-    else:
-        # InMemoryChatMemory는 user_id 무시
-        memory.clear(session_id)
-
-    return {"message": "Session cleared", "session_id": session_id}

--- a/poc/src/api/schemas.py
+++ b/poc/src/api/schemas.py
@@ -1,13 +1,13 @@
 """API 스키마 정의"""
 from typing import Optional, List
+from datetime import datetime
 from pydantic import BaseModel, Field
 
 
-class ChatRequest(BaseModel):
-    """채팅 요청"""
+class MessageRequest(BaseModel):
+    """메시지 전송 요청 (session_id는 path parameter, user_id는 Authorization header)"""
     message: str = Field(..., min_length=1, description="사용자 메시지")
-    session_id: Optional[str] = Field(None, description="세션 ID (없으면 히스토리 없이 처리)")
-    user_id: Optional[str] = Field(None, description="사용자 ID (선택 사항)")
+    stream: bool = Field(default=False, description="스트리밍 응답 여부")
 
 
 class ChatResponse(BaseModel):
@@ -17,10 +17,24 @@ class ChatResponse(BaseModel):
     session_id: Optional[str] = Field(None, description="세션 ID")
 
 
+class SessionCreateResponse(BaseModel):
+    """세션 생성 응답"""
+    session_id: str = Field(..., description="생성된 세션 ID")
+    created_at: str = Field(..., description="세션 생성 시간 (ISO 8601)")
+
+
 class SessionInfo(BaseModel):
     """세션 정보"""
     session_id: str
     message_count: int
+
+
+class SessionDetailResponse(BaseModel):
+    """세션 상세 정보"""
+    session_id: str = Field(..., description="세션 ID")
+    message_count: int = Field(..., description="메시지 개수")
+    created_at: Optional[str] = Field(None, description="세션 생성 시간")
+    last_activity: Optional[str] = Field(None, description="마지막 활동 시간")
 
 
 class SessionListResponse(BaseModel):

--- a/poc/src/memory/base.py
+++ b/poc/src/memory/base.py
@@ -65,6 +65,20 @@ class ChatMemory(ABC):
         """
         pass
 
+    @abstractmethod
+    def init_session(self, session_id: str, **kwargs) -> None:
+        """빈 세션 초기화 (세션 생성 시 호출)
+
+        Args:
+            session_id: 세션 식별자
+            **kwargs: 추가 메타데이터 (예: user_id)
+
+        Note:
+            - InMemory: 빈 리스트 생성
+            - Supabase: chat_sessions 테이블에 레코드 생성
+        """
+        pass
+
     def save_conversation(self, session_id: str, user_message: str, ai_message: str, **kwargs) -> None:
         """대화 쌍(사용자 + AI) 저장 - 편의 메서드
 

--- a/poc/src/memory/in_memory.py
+++ b/poc/src/memory/in_memory.py
@@ -80,3 +80,13 @@ class InMemoryChatMemory(ChatMemory):
         """세션의 메시지 개수"""
         with self._lock:
             return len(self._store[session_id])
+
+    def init_session(self, session_id: str) -> None:
+        """빈 세션 초기화 (세션 생성 시 호출)
+
+        Args:
+            session_id: 세션 식별자
+        """
+        with self._lock:
+            if session_id not in self._store:
+                self._store[session_id] = []

--- a/poc/src/memory/in_memory.py
+++ b/poc/src/memory/in_memory.py
@@ -5,6 +5,7 @@
 """
 import threading
 from collections import defaultdict
+from datetime import datetime, timezone
 from typing import List
 
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage
@@ -45,8 +46,10 @@ class InMemoryChatMemory(ChatMemory):
             msg = HumanMessage(content=content)
             # user_id는 메모리 계층 메타데이터이므로 LangChain 메시지에서 제외
             metadata = {k: v for k, v in kwargs.items() if k != 'user_id'}
-            if metadata:
-                msg.additional_kwargs.update(metadata)
+            # 타임스탬프 자동 추가
+            if 'timestamp' not in metadata:
+                metadata['timestamp'] = datetime.now(timezone.utc).isoformat()
+            msg.additional_kwargs.update(metadata)
             self._store[session_id].append(msg)
 
     def add_ai_message(self, session_id: str, content: str, **kwargs) -> None:
@@ -55,8 +58,10 @@ class InMemoryChatMemory(ChatMemory):
             msg = AIMessage(content=content)
             # user_id는 메모리 계층 메타데이터이므로 LangChain 메시지에서 제외
             metadata = {k: v for k, v in kwargs.items() if k != 'user_id'}
-            if metadata:
-                msg.additional_kwargs.update(metadata)
+            # 타임스탬프 자동 추가
+            if 'timestamp' not in metadata:
+                metadata['timestamp'] = datetime.now(timezone.utc).isoformat()
+            msg.additional_kwargs.update(metadata)
             self._store[session_id].append(msg)
 
     def clear(self, session_id: str) -> None:

--- a/poc/src/memory/supabase_memory.py
+++ b/poc/src/memory/supabase_memory.py
@@ -80,6 +80,18 @@ class SupabaseChatMemory(ChatMemory):
             logger.error(f"Error ensuring session {session_id}: {e}")
             return False
 
+    async def init_session_async(self, session_id: str, user_id: str) -> bool:
+        """빈 세션 초기화 (세션 생성 시 호출)
+
+        Args:
+            session_id: 세션 식별자
+            user_id: 사용자 ID (필수)
+
+        Returns:
+            True if session was created or already exists, False otherwise
+        """
+        return await self._ensure_session(session_id, user_id)
+
     async def get_messages_async(self, session_id: str, user_id: Optional[str] = None) -> List[BaseMessage]:
         """세션의 전체 대화 히스토리 조회 (비동기)
 

--- a/poc/static/index.html
+++ b/poc/static/index.html
@@ -873,6 +873,17 @@
             let thinkingBadge = null;  // thinking badge 요소
 
             try {
+                // 세션이 없으면 먼저 생성
+                if (!sessionId) {
+                    const sessionRes = await fetch('/v1/sessions', { method: 'POST' });
+                    if (!sessionRes.ok) {
+                        throw new Error('Failed to create session');
+                    }
+                    const sessionData = await sessionRes.json();
+                    sessionId = sessionData.session_id;
+                    document.getElementById('session-id').textContent = 'ID: ' + sessionId.substring(0, 8);
+                }
+
                 const response = await fetch('/v1/sessions/' + sessionId + '/messages', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
@@ -920,9 +931,8 @@
                                     addEventBadge('act', data.tool + '(' + JSON.stringify(data.args) + ')', assistantDiv);
                                 } else if (currentEventType === 'observe' && data.content) {
                                     addEventBadge('observe', data.content, assistantDiv);
-                                } else if (currentEventType === 'done' && data.session_id) {
-                                    sessionId = data.session_id;
-                                    document.getElementById('session-id').textContent = 'ID: ' + sessionId.substring(0, 8);
+                                } else if (currentEventType === 'done') {
+                                    // 세션 ID는 메시지 전송 전에 이미 설정됨
                                 } else if (currentEventType === 'error' && data.error) {
                                     addMessage('⚠️ 오류: ' + data.error, 'system');
                                 }

--- a/poc/static/index.html
+++ b/poc/static/index.html
@@ -639,7 +639,7 @@
         async function init() {
             initSuggestions();
             try {
-                const res = await fetch('/api/health');
+                const res = await fetch('/v1/health');
                 const data = await res.json();
                 document.getElementById('provider-badge').textContent = data.provider || 'Online';
                 document.getElementById('provider-badge').style.borderColor = 'rgba(74, 222, 128, 0.3)';
@@ -700,7 +700,7 @@
             if (!confirm('현재 대화 내역을 삭제하시겠습니까?')) return;
 
             try {
-                await fetch('/api/sessions/' + sessionId + '/messages', { method: 'DELETE' });
+                await fetch('/v1/sessions/' + sessionId, { method: 'DELETE' });
                 newSession();
             } catch (e) {
                 console.error('Failed to clear session:', e);
@@ -873,12 +873,12 @@
             let thinkingBadge = null;  // thinking badge 요소
 
             try {
-                const response = await fetch('/api/chat/stream', {
+                const response = await fetch('/v1/sessions/' + sessionId + '/messages', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         message: message,
-                        session_id: sessionId
+                        stream: true
                     })
                 });
 

--- a/poc/static/index.html
+++ b/poc/static/index.html
@@ -616,6 +616,28 @@
         let sessionId = null;
         let isStreaming = false;
 
+        // Authorization 헤더 생성 (Supabase 모드 지원)
+        // localStorage에 'userToken'이 설정되어 있으면 사용
+        function getAuthHeaders() {
+            const token = localStorage.getItem('userToken');
+            if (token) {
+                return { 'Authorization': 'Bearer ' + token };
+            }
+            return {};
+        }
+
+        // Supabase 모드용 토큰 설정 (콘솔에서 사용)
+        // 사용법: setUserToken('your-user-id')
+        window.setUserToken = function(token) {
+            if (token) {
+                localStorage.setItem('userToken', token);
+                console.log('User token set. Refresh to apply.');
+            } else {
+                localStorage.removeItem('userToken');
+                console.log('User token cleared.');
+            }
+        };
+
         const SUGGESTIONS = [
             '🚀 최신 AI 트렌드 요약해줘',
             '🐍 Python 리스트 컴프리헨션 예제',
@@ -700,7 +722,10 @@
             if (!confirm('현재 대화 내역을 삭제하시겠습니까?')) return;
 
             try {
-                await fetch('/v1/sessions/' + sessionId, { method: 'DELETE' });
+                await fetch('/v1/sessions/' + sessionId, {
+                    method: 'DELETE',
+                    headers: getAuthHeaders()
+                });
                 newSession();
             } catch (e) {
                 console.error('Failed to clear session:', e);
@@ -875,7 +900,10 @@
             try {
                 // 세션이 없으면 먼저 생성
                 if (!sessionId) {
-                    const sessionRes = await fetch('/v1/sessions', { method: 'POST' });
+                    const sessionRes = await fetch('/v1/sessions', {
+                        method: 'POST',
+                        headers: getAuthHeaders()
+                    });
                     if (!sessionRes.ok) {
                         throw new Error('Failed to create session');
                     }
@@ -886,7 +914,7 @@
 
                 const response = await fetch('/v1/sessions/' + sessionId + '/messages', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
                     body: JSON.stringify({
                         message: message,
                         stream: true

--- a/poc/tests/test_api_routes.py
+++ b/poc/tests/test_api_routes.py
@@ -48,10 +48,6 @@ class TestSessionEndpointsWithUserID:
             mock_memory.delete_session_async.__code__ = MagicMock()
             mock_memory.delete_session_async.__code__.co_varnames = ['self', 'session_id', 'user_id']
 
-            mock_memory.clear_async = AsyncMock()
-            mock_memory.clear_async.__code__ = MagicMock()
-            mock_memory.clear_async.__code__.co_varnames = ['self', 'session_id', 'user_id']
-
             mock_memory.get_messages_async = AsyncMock(return_value=[])
             mock_memory.get_messages_async.__code__ = MagicMock()
             mock_memory.get_messages_async.__code__.co_varnames = ['self', 'session_id', 'user_id']
@@ -59,10 +55,10 @@ class TestSessionEndpointsWithUserID:
             yield mock_memory
 
     def test_list_sessions_with_user_id(self, client, mock_supabase_memory):
-        """user_id를 포함하여 세션 목록 조회"""
+        """Authorization 헤더로 세션 목록 조회"""
         mock_supabase_memory.list_sessions_async.return_value = ["session-1", "session-2"]
 
-        response = client.get("/sessions?user_id=user-1")
+        response = client.get("/sessions", headers={"Authorization": "Bearer user-1"})
 
         assert response.status_code == 200
         data = response.json()
@@ -71,20 +67,20 @@ class TestSessionEndpointsWithUserID:
         # user_id로 필터링이 호출되었는지 확인
         mock_supabase_memory.list_sessions_async.assert_called_once_with(user_id="user-1")
 
-    def test_list_sessions_without_user_id_fails(self, client, mock_supabase_memory):
-        """user_id 없이 세션 목록 조회 시도 (Supabase 백엔드는 거부해야 함)"""
+    def test_list_sessions_without_auth_fails(self, client, mock_supabase_memory):
+        """Authorization 헤더 없이 세션 목록 조회 시도 (Supabase 백엔드는 거부해야 함)"""
         response = client.get("/sessions")
 
-        # Supabase 백엔드는 user_id 필수
-        assert response.status_code == 400
+        # Supabase 백엔드는 Authorization 헤더 필수
+        assert response.status_code == 401
         data = response.json()
-        assert "user_id is required" in data["detail"]
+        assert "Authorization header required" in data["detail"]
 
-    def test_delete_session_with_user_id(self, client, mock_supabase_memory):
-        """user_id를 포함하여 세션 삭제"""
+    def test_delete_session_with_auth(self, client, mock_supabase_memory):
+        """Authorization 헤더로 세션 삭제"""
         mock_supabase_memory.list_sessions_async.return_value = ["session-1"]
 
-        response = client.delete("/sessions/session-1?user_id=user-1")
+        response = client.delete("/sessions/session-1", headers={"Authorization": "Bearer user-1"})
 
         assert response.status_code == 200
         data = response.json()
@@ -94,51 +90,28 @@ class TestSessionEndpointsWithUserID:
         # user_id로 삭제가 호출되었는지 확인
         mock_supabase_memory.delete_session_async.assert_called_once_with("session-1", user_id="user-1")
 
-    def test_delete_session_without_user_id_fails(self, client, mock_supabase_memory):
-        """user_id 없이 세션 삭제 시도 (Supabase 백엔드는 거부해야 함)"""
+    def test_delete_session_without_auth_fails(self, client, mock_supabase_memory):
+        """Authorization 헤더 없이 세션 삭제 시도 (Supabase 백엔드는 거부해야 함)"""
         response = client.delete("/sessions/session-1")
 
-        # Supabase 백엔드는 user_id 필수
-        assert response.status_code == 400
+        # Supabase 백엔드는 Authorization 헤더 필수
+        assert response.status_code == 401
         data = response.json()
-        assert "user_id is required" in data["detail"]
+        assert "Authorization header required" in data["detail"]
 
     def test_delete_session_denies_access_for_wrong_user(self, client, mock_supabase_memory):
         """잘못된 user_id로는 세션 삭제 불가"""
         # user-1의 세션만 반환
         mock_supabase_memory.list_sessions_async.return_value = []
 
-        response = client.delete("/sessions/session-1?user_id=wrong-user")
+        response = client.delete("/sessions/session-1", headers={"Authorization": "Bearer wrong-user"})
 
         assert response.status_code == 404
         data = response.json()
         assert "not found" in data["detail"].lower() or "denied" in data["detail"].lower()
 
-    def test_clear_session_with_user_id(self, client, mock_supabase_memory):
-        """user_id를 포함하여 세션 메시지 초기화"""
-        mock_supabase_memory.list_sessions_async.return_value = ["session-1"]
-
-        response = client.delete("/sessions/session-1/messages?user_id=user-1")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["message"] == "Session cleared"
-        assert data["session_id"] == "session-1"
-
-        # user_id로 clear가 호출되었는지 확인
-        mock_supabase_memory.clear_async.assert_called_once_with("session-1", user_id="user-1")
-
-    def test_clear_session_without_user_id_fails(self, client, mock_supabase_memory):
-        """user_id 없이 세션 메시지 초기화 시도 (Supabase 백엔드는 거부해야 함)"""
-        response = client.delete("/sessions/session-1/messages")
-
-        # Supabase 백엔드는 user_id 필수
-        assert response.status_code == 400
-        data = response.json()
-        assert "user_id is required" in data["detail"]
-
-    def test_get_session_messages_with_user_id(self, client, mock_supabase_memory):
-        """user_id를 포함하여 세션 메시지 조회"""
+    def test_get_session_messages_with_auth(self, client, mock_supabase_memory):
+        """Authorization 헤더로 세션 메시지 조회"""
         # Mock messages
         mock_messages = [
             HumanMessage(content="Hello", additional_kwargs={"timestamp": "2024-01-01T00:00:00Z"}),
@@ -146,7 +119,7 @@ class TestSessionEndpointsWithUserID:
         ]
         mock_supabase_memory.get_messages_async.return_value = mock_messages
 
-        response = client.get("/sessions/session-1/messages?user_id=user-1")
+        response = client.get("/sessions/session-1/messages", headers={"Authorization": "Bearer user-1"})
 
         assert response.status_code == 200
         data = response.json()
@@ -160,14 +133,14 @@ class TestSessionEndpointsWithUserID:
         # user_id로 메시지 조회가 호출되었는지 확인
         mock_supabase_memory.get_messages_async.assert_called_once_with("session-1", user_id="user-1")
 
-    def test_get_session_messages_without_user_id_fails(self, client, mock_supabase_memory):
-        """user_id 없이 세션 메시지 조회 시도 (Supabase 백엔드는 거부해야 함)"""
+    def test_get_session_messages_without_auth_fails(self, client, mock_supabase_memory):
+        """Authorization 헤더 없이 세션 메시지 조회 시도 (Supabase 백엔드는 거부해야 함)"""
         response = client.get("/sessions/session-1/messages")
 
-        # Supabase 백엔드는 user_id 필수
-        assert response.status_code == 400
+        # Supabase 백엔드는 Authorization 헤더 필수
+        assert response.status_code == 401
         data = response.json()
-        assert "user_id is required" in data["detail"]
+        assert "Authorization header required" in data["detail"]
 
 
 class TestSessionEndpointsWithInMemory:
@@ -194,32 +167,28 @@ class TestSessionEndpointsWithInMemory:
             mock_memory.delete_session.__code__ = MagicMock()
             mock_memory.delete_session.__code__.co_varnames = ['self', 'session_id']
 
-            mock_memory.clear = MagicMock()
-            mock_memory.clear.__code__ = MagicMock()
-            mock_memory.clear.__code__.co_varnames = ['self', 'session_id']
-
             yield mock_memory
 
-    def test_list_sessions_ignores_user_id_for_inmemory(self, client, mock_inmemory):
-        """InMemoryChatMemory는 user_id를 무시"""
-        response = client.get("/sessions?user_id=user-1")
+    def test_list_sessions_ignores_auth_for_inmemory(self, client, mock_inmemory):
+        """InMemoryChatMemory는 Authorization 헤더를 무시"""
+        response = client.get("/sessions", headers={"Authorization": "Bearer user-1"})
 
         assert response.status_code == 200
 
         # user_id 없이 호출되었는지 확인 (InMemoryChatMemory는 user_id 파라미터가 없음)
         mock_inmemory.list_sessions.assert_called_once_with()
 
-    def test_delete_session_works_without_user_id_for_inmemory(self, client, mock_inmemory):
-        """InMemoryChatMemory는 user_id 없이 삭제"""
-        response = client.delete("/sessions/session-1?user_id=user-1")
+    def test_delete_session_works_with_auth_for_inmemory(self, client, mock_inmemory):
+        """InMemoryChatMemory는 Authorization 헤더를 무시하고 삭제"""
+        response = client.delete("/sessions/session-1", headers={"Authorization": "Bearer user-1"})
 
         assert response.status_code == 200
 
         # user_id 없이 호출되었는지 확인
         mock_inmemory.delete_session.assert_called_once_with("session-1")
 
-    def test_get_session_messages_ignores_user_id_for_inmemory(self, client, mock_inmemory):
-        """InMemoryChatMemory는 user_id를 무시하고 메시지 조회"""
+    def test_get_session_messages_ignores_auth_for_inmemory(self, client, mock_inmemory):
+        """InMemoryChatMemory는 Authorization 헤더를 무시하고 메시지 조회"""
         # Mock messages
         mock_messages = [
             HumanMessage(content="Test message"),
@@ -227,7 +196,7 @@ class TestSessionEndpointsWithInMemory:
         ]
         mock_inmemory.get_messages = MagicMock(return_value=mock_messages)
 
-        response = client.get("/sessions/session-1/messages?user_id=user-1")
+        response = client.get("/sessions/session-1/messages", headers={"Authorization": "Bearer user-1"})
 
         assert response.status_code == 200
         data = response.json()
@@ -238,88 +207,3 @@ class TestSessionEndpointsWithInMemory:
         mock_inmemory.get_messages.assert_called_once_with("session-1")
 
 
-class TestChatEndpoints:
-    """채팅 엔드포인트 테스트"""
-
-    @pytest.fixture
-    def mock_supervisor(self):
-        """Mock Supervisor"""
-        with patch('src.api.routes.supervisor') as mock_sup:
-            yield mock_sup
-
-    def test_chat_requires_user_id_with_supabase(self, client, mock_supervisor):
-        """POST /chat without user_id returns 400 with Supabase backend"""
-        with patch('src.api.routes.memory') as mock_memory:
-            mock_memory.__class__ = SupabaseChatMemory
-
-            response = client.post("/chat", json={"message": "hello"})
-
-            assert response.status_code == 400
-            data = response.json()
-            assert "user_id" in data["detail"].lower()
-
-    def test_chat_works_with_user_id_and_supabase(self, client, mock_supervisor):
-        """POST /chat with user_id succeeds with Supabase backend"""
-        with patch('src.api.routes.memory') as mock_memory:
-            mock_memory.__class__ = SupabaseChatMemory
-
-            # Mock supervisor response
-            from src.schemas.models import SupervisorResponse
-            mock_supervisor.process = AsyncMock(return_value=SupervisorResponse(
-                answer="Test response",
-                sources=["aweb_search"],
-                execution_log=[],
-                total_confidence=1.0
-            ))
-
-            response = client.post("/chat", json={
-                "message": "hello",
-                "user_id": "user-1"
-            })
-
-            assert response.status_code == 200
-            data = response.json()
-            assert data["answer"] == "Test response"
-            assert "session_id" in data
-
-            # Verify supervisor was called with user_id
-            mock_supervisor.process.assert_called_once()
-            call_kwargs = mock_supervisor.process.call_args.kwargs
-            assert call_kwargs["user_id"] == "user-1"
-
-    def test_chat_works_without_user_id_for_inmemory(self, client, mock_supervisor):
-        """POST /chat without user_id succeeds with InMemory backend"""
-        with patch('src.api.routes.memory') as mock_memory:
-            mock_memory.__class__ = InMemoryChatMemory
-
-            # Mock supervisor response
-            from src.schemas.models import SupervisorResponse
-            mock_supervisor.process = AsyncMock(return_value=SupervisorResponse(
-                answer="Test response",
-                sources=[],
-                execution_log=[],
-                total_confidence=1.0
-            ))
-
-            response = client.post("/chat", json={"message": "hello"})
-
-            assert response.status_code == 200
-            data = response.json()
-            assert data["answer"] == "Test response"
-
-    def test_chat_handles_supervisor_value_error(self, client, mock_supervisor):
-        """POST /chat returns 400 when Supervisor raises ValueError"""
-        with patch('src.api.routes.memory') as mock_memory:
-            mock_memory.__class__ = SupabaseChatMemory
-
-            # Mock supervisor to raise ValueError
-            mock_supervisor.process = AsyncMock(side_effect=ValueError("user_id is required"))
-
-            response = client.post("/chat", json={
-                "message": "hello",
-                "user_id": "user-1"
-            })
-
-            assert response.status_code == 400
-            data = response.json()
-            assert "user_id is required" in data["detail"]

--- a/poc/tests/test_restful_api.py
+++ b/poc/tests/test_restful_api.py
@@ -1,0 +1,425 @@
+"""RESTful API 테스트 (세션 중심 설계)"""
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock, patch, AsyncMock
+from datetime import datetime, timezone
+
+from src.api.routes import router
+from src.memory.supabase_memory import SupabaseChatMemory
+from src.memory import InMemoryChatMemory
+from fastapi import FastAPI
+from langchain_core.messages import HumanMessage, AIMessage
+
+
+@pytest.fixture
+def app():
+    """FastAPI 앱 인스턴스"""
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client(app):
+    """테스트 클라이언트"""
+    return TestClient(app)
+
+
+class TestSessionCreation:
+    """POST /sessions - 세션 생성 테스트"""
+
+    def test_create_session_returns_session_id_and_timestamp(self, client):
+        """세션 생성 시 session_id와 created_at 반환"""
+        response = client.post("/sessions")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "session_id" in data
+        assert "created_at" in data
+
+        # UUID 형식 검증
+        import uuid
+        try:
+            uuid.UUID(data["session_id"])
+        except ValueError:
+            pytest.fail("session_id is not a valid UUID")
+
+        # ISO 8601 타임스탬프 검증
+        try:
+            datetime.fromisoformat(data["created_at"].replace("Z", "+00:00"))
+        except ValueError:
+            pytest.fail("created_at is not a valid ISO 8601 timestamp")
+
+    def test_create_session_calls_init_session_for_inmemory(self, client):
+        """InMemory 백엔드: 세션 생성 시 init_session 호출 검증"""
+        with patch('src.api.routes.memory') as mock_memory:
+            mock_memory.__class__ = InMemoryChatMemory
+            mock_memory.spec = InMemoryChatMemory
+            mock_memory.init_session = MagicMock()
+
+            response = client.post("/sessions")
+
+            assert response.status_code == 200
+            data = response.json()
+
+            # init_session이 생성된 session_id로 호출되었는지 검증
+            mock_memory.init_session.assert_called_once()
+            call_args = mock_memory.init_session.call_args
+            assert call_args[0][0] == data["session_id"]
+
+    def test_create_session_calls_init_session_async_for_supabase(self, client):
+        """Supabase 백엔드: 세션 생성 시 init_session_async 호출 검증"""
+        with patch('src.api.routes.memory') as mock_memory:
+            mock_memory.__class__ = SupabaseChatMemory
+            mock_memory.spec = SupabaseChatMemory
+            mock_memory.init_session_async = AsyncMock(return_value=True)
+
+            response = client.post(
+                "/sessions",
+                headers={"Authorization": "Bearer user-1"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+
+            # init_session_async가 session_id와 user_id로 호출되었는지 검증
+            mock_memory.init_session_async.assert_called_once()
+            call_args = mock_memory.init_session_async.call_args
+            assert call_args[0][0] == data["session_id"]
+            assert call_args[0][1] == "user-1"
+
+    def test_create_session_fails_when_supabase_init_fails(self, client):
+        """Supabase 백엔드: 세션 초기화 실패 시 500 에러"""
+        with patch('src.api.routes.memory') as mock_memory:
+            mock_memory.__class__ = SupabaseChatMemory
+            mock_memory.spec = SupabaseChatMemory
+            mock_memory.init_session_async = AsyncMock(return_value=False)
+
+            response = client.post(
+                "/sessions",
+                headers={"Authorization": "Bearer user-1"}
+            )
+
+            assert response.status_code == 500
+            data = response.json()
+            assert "Failed to create session" in data["detail"]
+
+
+class TestSessionDetail:
+    """GET /sessions/{session_id} - 세션 상세 조회 테스트"""
+
+    @pytest.fixture
+    def mock_supabase_memory(self):
+        """Mock SupabaseChatMemory"""
+        with patch('src.api.routes.memory') as mock_memory:
+            mock_memory.__class__ = SupabaseChatMemory
+            mock_memory.spec = SupabaseChatMemory
+
+            # Configure async methods
+            mock_memory.list_sessions_async = AsyncMock()
+            mock_memory.get_message_count_async = AsyncMock()
+            mock_memory.get_messages_async = AsyncMock()
+
+            yield mock_memory
+
+    def test_get_session_detail_with_messages(self, client, mock_supabase_memory):
+        """메시지가 있는 세션 상세 조회"""
+        session_id = "test-session-123"
+
+        # Mock 데이터 설정
+        mock_supabase_memory.list_sessions_async.return_value = [session_id]
+        mock_supabase_memory.get_message_count_async.return_value = 4
+
+        # 타임스탬프가 있는 메시지 목록
+        mock_messages = [
+            HumanMessage(
+                content="First message",
+                additional_kwargs={"timestamp": "2024-01-01T10:00:00Z"}
+            ),
+            AIMessage(
+                content="First response",
+                additional_kwargs={"timestamp": "2024-01-01T10:00:05Z"}
+            ),
+            HumanMessage(
+                content="Second message",
+                additional_kwargs={"timestamp": "2024-01-01T10:01:00Z"}
+            ),
+            AIMessage(
+                content="Second response",
+                additional_kwargs={"timestamp": "2024-01-01T10:01:10Z"}
+            ),
+        ]
+        mock_supabase_memory.get_messages_async.return_value = mock_messages
+
+        response = client.get(
+            f"/sessions/{session_id}",
+            headers={"Authorization": "Bearer user-1"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["session_id"] == session_id
+        assert data["message_count"] == 4
+        assert data["created_at"] == "2024-01-01T10:00:00Z"
+        assert data["last_activity"] == "2024-01-01T10:01:10Z"
+
+    def test_get_session_detail_without_auth_fails_for_supabase(
+        self, client, mock_supabase_memory
+    ):
+        """Supabase 백엔드에서 Authorization 헤더 없이 조회 시도"""
+        session_id = "test-session-123"
+
+        response = client.get(f"/sessions/{session_id}")
+
+        assert response.status_code == 401
+        data = response.json()
+        assert "Authorization header required" in data["detail"]
+
+    def test_get_session_detail_not_found(self, client, mock_supabase_memory):
+        """존재하지 않는 세션 조회"""
+        session_id = "nonexistent-session"
+
+        mock_supabase_memory.list_sessions_async.return_value = []
+
+        response = client.get(
+            f"/sessions/{session_id}",
+            headers={"Authorization": "Bearer user-1"}
+        )
+
+        assert response.status_code == 404
+        data = response.json()
+        assert "not found" in data["detail"].lower() or "denied" in data["detail"].lower()
+
+    def test_get_session_detail_with_inmemory(self, client):
+        """InMemory 백엔드로 세션 상세 조회"""
+        with patch('src.api.routes.memory') as mock_memory:
+            mock_memory.__class__ = InMemoryChatMemory
+            mock_memory.spec = InMemoryChatMemory
+
+            session_id = "test-session"
+            mock_memory.list_sessions.return_value = [session_id]
+            mock_memory.get_message_count.return_value = 2
+            mock_memory.get_messages.return_value = [
+                HumanMessage(
+                    content="Hi",
+                    additional_kwargs={"timestamp": "2024-01-01T12:00:00Z"}
+                ),
+                AIMessage(
+                    content="Hello",
+                    additional_kwargs={"timestamp": "2024-01-01T12:00:05Z"}
+                ),
+            ]
+
+            response = client.get(f"/sessions/{session_id}")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["session_id"] == session_id
+            assert data["message_count"] == 2
+            assert data["created_at"] == "2024-01-01T12:00:00Z"
+            assert data["last_activity"] == "2024-01-01T12:00:05Z"
+
+
+class TestSendMessage:
+    """POST /sessions/{session_id}/messages - stream 파라미터 기반 응답"""
+
+    @pytest.fixture
+    def mock_supervisor(self):
+        """Mock Supervisor"""
+        with patch('src.api.routes.supervisor') as mock_sup:
+            yield mock_sup
+
+    @pytest.fixture
+    def mock_supabase_memory(self):
+        """Mock SupabaseChatMemory"""
+        with patch('src.api.routes.memory') as mock_memory:
+            mock_memory.__class__ = SupabaseChatMemory
+            mock_memory.spec = SupabaseChatMemory
+            yield mock_memory
+
+    def test_send_message_json_response(self, client, mock_supervisor, mock_supabase_memory):
+        """stream: false → JSON 응답"""
+        session_id = "test-session"
+
+        # Mock supervisor response
+        from src.schemas.models import SupervisorResponse
+        mock_supervisor.process = AsyncMock(return_value=SupervisorResponse(
+            answer="This is a JSON response",
+            sources=["web_search"],
+            execution_log=[],
+            total_confidence=1.0
+        ))
+
+        response = client.post(
+            f"/sessions/{session_id}/messages",
+            json={"message": "Hello", "stream": False},
+            headers={"Authorization": "Bearer user-1"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["answer"] == "This is a JSON response"
+        assert data["sources"] == ["web_search"]
+        assert data["session_id"] == session_id
+
+        # Verify supervisor was called
+        mock_supervisor.process.assert_called_once()
+        call_kwargs = mock_supervisor.process.call_args.kwargs
+        assert call_kwargs["question"] == "Hello"
+        assert call_kwargs["session_id"] == session_id
+        assert call_kwargs["user_id"] == "user-1"
+
+    def test_send_message_streaming_response(self, client, mock_supervisor, mock_supabase_memory):
+        """stream: true → SSE 스트리밍"""
+        session_id = "test-session"
+
+        # Mock streaming response - return the generator function itself
+        async def mock_stream(question, session_id, **kwargs):
+            yield {"type": "token", "content": "Hello"}
+            yield {"type": "token", "content": " World"}
+            yield {"type": "think", "content": "Thinking..."}
+            yield {"type": "act", "tool": "search", "args": {"query": "test"}}
+            yield {"type": "observe", "content": "Search results"}
+
+        mock_supervisor.process_stream = mock_stream
+
+        response = client.post(
+            f"/sessions/{session_id}/messages",
+            json={"message": "Hello", "stream": True},
+            headers={"Authorization": "Bearer user-1"}
+        )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+
+        # SSE 응답 검증
+        content = response.text
+        assert "event: token" in content
+        assert "event: think" in content
+        assert "event: act" in content
+        assert "event: observe" in content
+        assert "event: done" in content
+
+    def test_send_message_defaults_to_json(
+        self, client, mock_supervisor, mock_supabase_memory
+    ):
+        """stream 미지정 시 JSON 응답 (기본값)"""
+        session_id = "test-session"
+
+        from src.schemas.models import SupervisorResponse
+        mock_supervisor.process = AsyncMock(return_value=SupervisorResponse(
+            answer="Default JSON response",
+            sources=[],
+            execution_log=[],
+            total_confidence=1.0
+        ))
+
+        # stream 파라미터 없이 요청
+        response = client.post(
+            f"/sessions/{session_id}/messages",
+            json={"message": "Test"},
+            headers={"Authorization": "Bearer user-1"}
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["answer"] == "Default JSON response"
+
+    def test_send_message_requires_auth_for_supabase(self, client, mock_supabase_memory):
+        """Supabase 백엔드에서 Authorization 헤더 필수"""
+        session_id = "test-session"
+
+        response = client.post(
+            f"/sessions/{session_id}/messages",
+            json={"message": "Hello"}
+        )
+
+        assert response.status_code == 401
+        data = response.json()
+        assert "Authorization header required" in data["detail"]
+
+    def test_send_message_works_without_auth_for_inmemory(self, client, mock_supervisor):
+        """InMemory 백엔드는 Authorization 헤더 불필요"""
+        with patch('src.api.routes.memory') as mock_memory:
+            mock_memory.__class__ = InMemoryChatMemory
+            mock_memory.spec = InMemoryChatMemory
+
+            session_id = "test-session"
+
+            from src.schemas.models import SupervisorResponse
+            mock_supervisor.process = AsyncMock(return_value=SupervisorResponse(
+                answer="Response without auth",
+                sources=[],
+                execution_log=[],
+                total_confidence=1.0
+            ))
+
+            response = client.post(
+                f"/sessions/{session_id}/messages",
+                json={"message": "Hello"}
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["answer"] == "Response without auth"
+
+    def test_send_message_streaming_handles_error(self, client, mock_supervisor, mock_supabase_memory):
+        """스트리밍 중 에러 발생 시 error 이벤트"""
+        session_id = "test-session"
+
+        # Mock error during streaming
+        async def mock_error_stream(question, session_id, **kwargs):
+            yield {"type": "token", "content": "Start"}
+            raise ValueError("Test error")
+
+        mock_supervisor.process_stream = mock_error_stream
+
+        response = client.post(
+            f"/sessions/{session_id}/messages",
+            json={"message": "Hello", "stream": True},
+            headers={"Authorization": "Bearer user-1"}
+        )
+
+        assert response.status_code == 200
+        content = response.text
+        assert "event: error" in content
+
+    def test_send_message_json_handles_validation_error(
+        self, client, mock_supervisor, mock_supabase_memory
+    ):
+        """JSON 모드에서 ValidationError 처리"""
+        session_id = "test-session"
+
+        mock_supervisor.process = AsyncMock(side_effect=ValueError("Validation failed"))
+
+        response = client.post(
+            f"/sessions/{session_id}/messages",
+            json={"message": "Hello", "stream": False},
+            headers={"Authorization": "Bearer user-1"}
+        )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert "Validation failed" in data["detail"]
+
+
+class TestAPIDocumentation:
+    """OpenAPI 문서 자동 생성 확인"""
+
+    def test_openapi_schema_includes_new_endpoints(self, client):
+        """OpenAPI 스키마에 새 엔드포인트 포함"""
+        response = client.get("/openapi.json")
+
+        assert response.status_code == 200
+        schema = response.json()
+        paths = schema["paths"]
+
+        # RESTful 엔드포인트 확인
+        assert "/sessions" in paths
+        assert "/sessions/{session_id}" in paths
+        assert "/sessions/{session_id}/messages" in paths
+        assert "/health" in paths
+
+        # 기존 엔드포인트는 제거됨
+        assert "/chat" not in paths
+        assert "/chat/stream" not in paths

--- a/poc/tests/test_restful_api.py
+++ b/poc/tests/test_restful_api.py
@@ -1,4 +1,6 @@
 """RESTful API 테스트 (세션 중심 설계)"""
+import uuid
+
 import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import MagicMock, patch, AsyncMock
@@ -7,6 +9,7 @@ from datetime import datetime, timezone
 from src.api.routes import router
 from src.memory.supabase_memory import SupabaseChatMemory
 from src.memory import InMemoryChatMemory
+from src.schemas.models import SupervisorResponse
 from fastapi import FastAPI
 from langchain_core.messages import HumanMessage, AIMessage
 
@@ -38,7 +41,6 @@ class TestSessionCreation:
         assert "created_at" in data
 
         # UUID 형식 검증
-        import uuid
         try:
             uuid.UUID(data["session_id"])
         except ValueError:
@@ -242,7 +244,6 @@ class TestSendMessage:
         session_id = "test-session"
 
         # Mock supervisor response
-        from src.schemas.models import SupervisorResponse
         mock_supervisor.process = AsyncMock(return_value=SupervisorResponse(
             answer="This is a JSON response",
             sources=["web_search"],
@@ -306,7 +307,6 @@ class TestSendMessage:
         """stream 미지정 시 JSON 응답 (기본값)"""
         session_id = "test-session"
 
-        from src.schemas.models import SupervisorResponse
         mock_supervisor.process = AsyncMock(return_value=SupervisorResponse(
             answer="Default JSON response",
             sources=[],
@@ -346,7 +346,6 @@ class TestSendMessage:
 
             session_id = "test-session"
 
-            from src.schemas.models import SupervisorResponse
             mock_supervisor.process = AsyncMock(return_value=SupervisorResponse(
                 answer="Response without auth",
                 sources=[],


### PR DESCRIPTION
## Summary
- API prefix `/api` → `/v1` 변경
- 인증 방식 query parameter → `Authorization: Bearer <token>` header
- `/chat`, `/chat/stream` → `/sessions/{id}/messages` 통합 (`stream` 파라미터로 구분)
- 새 엔드포인트: `POST /sessions`, `GET /sessions/{id}`
- `ChatMemory.init_session()` 추상 메서드 추가
- 헬퍼 함수 추출: `require_user_id()`, `_extract_timestamps()`

## Breaking Changes
| 항목 | 이전 | 변경 후 |
|------|------|---------|
| API Prefix | `/api` | `/v1` |
| 인증 방식 | `?user_id=xxx` | `Authorization: Bearer xxx` |
| 채팅 | `POST /chat`, `/chat/stream` | `POST /sessions/{id}/messages` |
| 세션 생성 | (없음) | `POST /sessions` |
| 세션 상세 | (없음) | `GET /sessions/{id}` |
| 세션 초기화 | `DELETE /sessions/{id}/messages` | (제거됨) |

## Test plan
- [x] 테스트 26개 통과 (`uv run pytest tests/test_api_routes.py tests/test_restful_api.py -v`)
- [ ] 프론트엔드 API 호출 업데이트 확인
- [ ] Supabase 연동 테스트